### PR TITLE
Add copy into array

### DIFF
--- a/VectorMath.hx
+++ b/VectorMath.hx
@@ -607,6 +607,18 @@ abstract Vec2(Vec2Data) to Vec2Data from Vec2Data {
 		return this;
 	}
 
+	@:overload(function<T>(arrayLike: T, index: Int): T {})
+	public macro function copyIntoArray(self: ExprOf<Vec4>, array: ExprOf<ArrayAccess<Float>>, index: ExprOf<Int>) {
+		return macro {
+			var self = $self;
+			var array = $array;
+			var i: Int = $index;
+			array[0 + i] = self.x;
+			array[1 + i] = self.y;
+			array;
+		}
+	}
+
 	public inline function clone() {
 		return new Vec2(x, y);
 	}
@@ -1000,6 +1012,19 @@ abstract Vec3(Vec3Data) to Vec3Data from Vec3Data {
 		y = v.y;
 		z = v.z;
 		return this;
+	}
+
+	@:overload(function<T>(arrayLike: T, index: Int): T {})
+	public macro function copyIntoArray(self: ExprOf<Vec4>, array: ExprOf<ArrayAccess<Float>>, index: ExprOf<Int>) {
+		return macro {
+			var self = $self;
+			var array = $array;
+			var i: Int = $index;
+			array[0 + i] = self.x;
+			array[1 + i] = self.y;
+			array[2 + i] = self.z;
+			array;
+		}
 	}
 
 	public inline function clone() {
@@ -1433,6 +1458,20 @@ abstract Vec4(Vec4Data) to Vec4Data from Vec4Data {
 		z = v.z;
 		w = v.w;
 		return this;
+	}
+
+	@:overload(function<T>(arrayLike: T, index: Int): T {})
+	public macro function copyIntoArray(self: ExprOf<Vec4>, array: ExprOf<ArrayAccess<Float>>, index: ExprOf<Int>) {
+		return macro {
+			var self = $self;
+			var array = $array;
+			var i: Int = $index;
+			array[0 + i] = self.x;
+			array[1 + i] = self.y;
+			array[2 + i] = self.z;
+			array[3 + i] = self.w;
+			array;
+		}
 	}
 
 	public inline function clone() {
@@ -1876,6 +1915,18 @@ abstract Mat2(Mat2Data) from Mat2Data to Mat2Data {
 		return this;
 	}
 
+	@:overload(function<T>(arrayLike: T, index: Int): T {})
+	public macro function copyIntoArray(self: ExprOf<Vec4>, array: ExprOf<ArrayAccess<Float>>, index: ExprOf<Int>) {
+		return macro  {
+			var self = $self;
+			var array = $array;
+			var i: Int = $index;
+			self[0].copyIntoArray(array, i);
+			self[1].copyIntoArray(array, i + 2);
+			array;
+		}
+	}
+
 	public inline function clone(): Mat2 {
 		return new Mat2(
 			this.c0.x, this.c0.y,
@@ -2150,6 +2201,19 @@ abstract Mat3(Mat3Data) from Mat3Data to Mat3Data {
 		this.c1.copyFrom(v.c1);
 		this.c2.copyFrom(v.c2);
 		return this;
+	}
+
+	@:overload(function<T>(arrayLike: T, index: Int): T {})
+	public macro function copyIntoArray(self: ExprOf<Vec4>, array: ExprOf<ArrayAccess<Float>>, index: ExprOf<Int>) {
+		return macro  {
+			var self = $self;
+			var array = $array;
+			var i: Int = $index;
+			self[0].copyIntoArray(array, i);
+			self[1].copyIntoArray(array, i + 3);
+			self[2].copyIntoArray(array, i + 6);
+			array;
+		}
 	}
 
 	public inline function clone(): Mat3 {
@@ -2449,6 +2513,20 @@ abstract Mat4(Mat4Data) from Mat4Data to Mat4Data {
 		this.c2.copyFrom(v.c2);
 		this.c3.copyFrom(v.c3);
 		return this;
+	}
+
+	@:overload(function<T>(arrayLike: T, index: Int): T {})
+	public macro function copyIntoArray(self: ExprOf<Vec4>, array: ExprOf<ArrayAccess<Float>>, index: ExprOf<Int>) {
+		return macro  {
+			var self = $self;
+			var array = $array;
+			var i: Int = $index;
+			self[0].copyIntoArray(array, i);
+			self[1].copyIntoArray(array, i + 4);
+			self[2].copyIntoArray(array, i + 8);
+			self[3].copyIntoArray(array, i + 12);
+			array;
+		}
 	}
 
 	public inline function clone(): Mat4 {

--- a/VectorMath.hx
+++ b/VectorMath.hx
@@ -1915,6 +1915,9 @@ abstract Mat2(Mat2Data) from Mat2Data to Mat2Data {
 		return this;
 	}
 
+	/**
+		Copies matrix elements in column-major order into a type that supports array-write access
+	**/
 	@:overload(function<T>(arrayLike: T, index: Int): T {})
 	public macro function copyIntoArray(self: ExprOf<Vec4>, array: ExprOf<ArrayAccess<Float>>, index: ExprOf<Int>) {
 		return macro  {
@@ -2203,6 +2206,9 @@ abstract Mat3(Mat3Data) from Mat3Data to Mat3Data {
 		return this;
 	}
 
+	/**
+		Copies matrix elements in column-major order into a type that supports array-write access
+	**/
 	@:overload(function<T>(arrayLike: T, index: Int): T {})
 	public macro function copyIntoArray(self: ExprOf<Vec4>, array: ExprOf<ArrayAccess<Float>>, index: ExprOf<Int>) {
 		return macro  {
@@ -2515,6 +2521,9 @@ abstract Mat4(Mat4Data) from Mat4Data to Mat4Data {
 		return this;
 	}
 
+	/**
+		Copies matrix elements in column-major order into a type that supports array-write access
+	**/
 	@:overload(function<T>(arrayLike: T, index: Int): T {})
 	public macro function copyIntoArray(self: ExprOf<Vec4>, array: ExprOf<ArrayAccess<Float>>, index: ExprOf<Int>) {
 		return macro  {

--- a/test/Main.hx
+++ b/test/Main.hx
@@ -11,6 +11,27 @@ function main() {
 	testsStart();
 
 	// ------------
+	// -- Mat2
+	// ------------
+	test({
+		var expected = [
+			2, 3,
+			11,13
+		];
+		var result = mat2(
+			2, 3,
+			11,13
+		).copyIntoArray([], 0);
+		var matching = true;
+		for (i in 0...expected.length) {
+			if (expected[i] != result[i]) {
+				matching = false; break;
+			}
+		}
+		matching;
+	});
+
+	// ------------
 	// -- Mat3
 	// ------------	
 
@@ -133,6 +154,25 @@ function main() {
 		var _m = m.clone();
 		m -= n;
 		m == _m - n;
+	});
+	test({
+		var expected = [
+			2, 3, 5, 
+			11,13,17,
+			23,29,31
+		];
+		var result = mat3(
+			2, 3, 5,
+			11,13,17,
+			23,29,31
+		).copyIntoArray([], 0);
+		var matching = true;
+		for (i in 0...expected.length) {
+			if (expected[i] != result[i]) {
+				matching = false; break;
+			}
+		}
+		matching;
 	});
 
 	// ------------
@@ -414,6 +454,27 @@ function main() {
 			1/41,1/43,1/47,1/53
 		)
 	);
+	test({
+		var expected = [
+			2, 3, 5, 7,
+			11,13,17,19,
+			23,29,31,37,
+			41,43,47,53
+		];
+		var result = mat4(
+			2, 3, 5, 7,
+			11,13,17,19,
+			23,29,31,37,
+			41,43,47,53
+		).copyIntoArray([], 0);
+		var matching = true;
+		for (i in 0...expected.length) {
+			if (expected[i] != result[i]) {
+				matching = false; break;
+			}
+		}
+		matching;
+	});
 
 	// ------------
 	// # Misc


### PR DESCRIPTION
Adds new field to address #4 – need to ensure this works well in generated native shader code
`mat4(1.0).copyIntoArray(array, 0)`

Implemented as macro instance field so that any type that supports array access can be used