### PR TITLE
Workaround for nasty ternary closure codegen for min/max on Lua target

### DIFF
--- a/Vec2.hx
+++ b/Vec2.hx
@@ -158,28 +158,56 @@ abstract Vec2(Vec2Data) to Vec2Data from Vec2Data {
 		return (this: Vec2) - d * ((this: Vec2) / d).floor();
 	}
 	public extern overload inline function min(b: Vec2): Vec2 {
+		#if lua
+		return new Vec2(
+			lua.Math.min(b.x, x),
+			lua.Math.min(b.y, y)
+		);
+		#else
 		return new Vec2(
 			b.x < x ? b.x : x,
 			b.y < y ? b.y : y
 		);
+		#end
 	}
 	public extern overload inline function min(b: Float): Vec2 {
+		#if lua
+		return new Vec2(
+			lua.Math.min(b, x),
+			lua.Math.min(b, y)
+		);
+		#else
 		return new Vec2(
 			b < x ? b : x,
 			b < y ? b : y
 		);
+		#end
 	}
 	public extern overload inline function max(b: Vec2): Vec2 {
+		#if lua
+		return new Vec2(
+			lua.Math.max(b.x, x),
+			lua.Math.max(b.y, y)
+		);
+		#else
 		return new Vec2(
 			x < b.x ? b.x : x,
 			y < b.y ? b.y : y
 		);
+		#end
 	}
 	public extern overload inline function max(b: Float): Vec2 {
+		#if lua
+		return new Vec2(
+			lua.Math.max(b, x),
+			lua.Math.max(b, y)
+		);
+		#else
 		return new Vec2(
 			x < b ? b : x,
 			y < b ? b : y
 		);
+		#end
 	}
 	public extern overload inline function clamp(minLimit: Vec2, maxLimit: Vec2) {
 		return max(minLimit).min(maxLimit);

--- a/Vec3.hx
+++ b/Vec3.hx
@@ -187,32 +187,64 @@ abstract Vec3(Vec3Data) to Vec3Data from Vec3Data {
 		return (this: Vec3) - d * ((this: Vec3) / d).floor();
 	}
 	public extern overload inline function min(b: Vec3): Vec3 {
+		#if lua
+		return new Vec3(
+			lua.Math.min(b.x, x),
+			lua.Math.min(b.y, y),
+			lua.Math.min(b.z, z)
+		);
+		#else
 		return new Vec3(
 			b.x < x ? b.x : x,
 			b.y < y ? b.y : y,
 			b.z < z ? b.z : z
 		);
+		#end
 	}
 	public extern overload inline function min(b: Float): Vec3 {
+		#if lua
+		return new Vec3(
+			lua.Math.min(b, x),
+			lua.Math.min(b, y),
+			lua.Math.min(b, z)
+		);
+		#else
 		return new Vec3(
 			b < x ? b : x,
 			b < y ? b : y,
 			b < z ? b : z
 		);
+		#end
 	}
 	public extern overload inline function max(b: Vec3): Vec3 {
+		#if lua
+		return new Vec3(
+			lua.Math.max(b.x, x),
+			lua.Math.max(b.y, y),
+			lua.Math.max(b.z, z)
+		);
+		#else
 		return new Vec3(
 			x < b.x ? b.x : x,
 			y < b.y ? b.y : y,
 			z < b.z ? b.z : z
 		);
+		#end
 	}
 	public extern overload inline function max(b: Float): Vec3 {
+		#if lua
+		return new Vec3(
+			lua.Math.max(b, x),
+			lua.Math.max(b, y),
+			lua.Math.max(b, z)
+		);
+		#else
 		return new Vec3(
 			x < b ? b : x,
 			y < b ? b : y,
 			z < b ? b : z
 		);
+		#end
 	}
 	public extern overload inline function clamp(minLimit: Vec3, maxLimit: Vec3) {
 		return max(minLimit).min(maxLimit);

--- a/Vec4.hx
+++ b/Vec4.hx
@@ -236,10 +236,10 @@ abstract Vec4(Vec4Data) to Vec4Data from Vec4Data {
 	public extern overload inline function max(b: Vec4): Vec4 {
 		#if lua
 		return new Vec4(
-			lua.Math.min(b.x, x),
-			lua.Math.min(b.y, y),
-			lua.Math.min(b.z, z),
-			lua.Math.min(b.w, w)
+			lua.Math.max(b.x, x),
+			lua.Math.max(b.y, y),
+			lua.Math.max(b.z, z),
+			lua.Math.max(b.w, w)
 		);
 		#else
 		return new Vec4(
@@ -253,10 +253,10 @@ abstract Vec4(Vec4Data) to Vec4Data from Vec4Data {
 	public extern overload inline function max(b: Float): Vec4 {
 		#if lua
 		return new Vec4(
-			lua.Math.min(b, x),
-			lua.Math.min(b, y),
-			lua.Math.min(b, z),
-			lua.Math.min(b, w)
+			lua.Math.max(b, x),
+			lua.Math.max(b, y),
+			lua.Math.max(b, z),
+			lua.Math.max(b, w)
 		);
 		#else
 		return new Vec4(

--- a/Vec4.hx
+++ b/Vec4.hx
@@ -200,36 +200,72 @@ abstract Vec4(Vec4Data) to Vec4Data from Vec4Data {
 		return (this: Vec4) - d * ((this: Vec4) / d).floor();
 	}
 	public extern overload inline function min(b: Vec4): Vec4 {
+		#if lua
+		return new Vec4(
+			lua.Math.min(b.x, x),
+			lua.Math.min(b.y, y),
+			lua.Math.min(b.z, z),
+			lua.Math.min(b.w, w)
+		);
+		#else
 		return new Vec4(
 			b.x < x ? b.x : x,
 			b.y < y ? b.y : y,
 			b.z < z ? b.z : z,
 			b.w < w ? b.w : w
 		);
+		#end
 	}
 	public extern overload inline function min(b: Float): Vec4 {
+		#if lua
+		return new Vec4(
+			lua.Math.min(b, x),
+			lua.Math.min(b, y),
+			lua.Math.min(b, z),
+			lua.Math.min(b, w)
+		);
+		#else
 		return new Vec4(
 			b < x ? b : x,
 			b < y ? b : y,
 			b < z ? b : z,
 			b < w ? b : w
 		);
+		#end
 	}
 	public extern overload inline function max(b: Vec4): Vec4 {
+		#if lua
+		return new Vec4(
+			lua.Math.min(b.x, x),
+			lua.Math.min(b.y, y),
+			lua.Math.min(b.z, z),
+			lua.Math.min(b.w, w)
+		);
+		#else
 		return new Vec4(
 			x < b.x ? b.x : x,
 			y < b.y ? b.y : y,
 			z < b.z ? b.z : z,
 			w < b.w ? b.w : w
 		);
+		#end
 	}
 	public extern overload inline function max(b: Float): Vec4 {
+		#if lua
+		return new Vec4(
+			lua.Math.min(b, x),
+			lua.Math.min(b, y),
+			lua.Math.min(b, z),
+			lua.Math.min(b, w)
+		);
+		#else
 		return new Vec4(
 			x < b ? b : x,
 			y < b ? b : y,
 			z < b ? b : z,
 			w < b ? b : w
 		);
+		#end
 	}
 	public extern overload inline function clamp(minLimit: Vec4, maxLimit: Vec4) {
 		return max(minLimit).min(maxLimit);


### PR DESCRIPTION
This is pretty gross to do, so I don't know if you'll want to merge it, but the codegen for ternaries on Lua target is truly terrible and I thought I'd bring it up. I think this is also the only set of functions where switching it to a Lua builtin would be relevant, everything else would just need a plain `if` instead of ternary.

This also affects every other usage of ternaries such as in `sign`, `step`,` normalize`, `faceforward` and `reflect`, I just picked on `min`/`max` first because there's a standard function for it. I don't think other targets have this codegen problem, but spitting out this many closures constantly does have gc/perf consequences on Lua.

Before:
```lua
local min = Vec3Data.new((function() 
  local _hx_1
  if (b.x < p.x) then 
  _hx_1 = b.x; else 
  _hx_1 = p.x; end
  return _hx_1
end )(), (function() 
  local _hx_2
  if (b.y < p.y) then 
  _hx_2 = b.y; else 
  _hx_2 = p.y; end
  return _hx_2
end )(), (function() 
  local _hx_3
  if (b.z < p.z) then 
  _hx_3 = b.z; else 
  _hx_3 = p.z; end
  return _hx_3
end )());
```

After:
```lua
local min = Vec3Data.new(_G.math.min(b.x, p.x), _G.math.min(b.y, p.y), _G.math.min(b.z, p.z));
```

Alternatively without the special casing:
```haxe
public extern overload inline function min(b: Vec3): Vec3 {
	var mx = x;
	var my = y;
	var mz = z;
	if (b.x < x) { mx = b.x; }
	if (b.y < y) { my = b.y; }
	if (b.z < z) { mz = b.z; }
	return new Vec3(mx, my, mz);
}
```

outputs:

```lua
local mx = p.x;
local my = p.y;
local mz = p.z;
if (b.x < p.x) then 
  mx = b.x;
end;
if (b.y < p.y) then 
  my = b.y;
end;
if (b.z < p.z) then 
  mz = b.z;
end;
local min = Vec3Data.new(mx, my, mz);
```

(all results from haxe 4.2.5 using `-D lua-vanilla -D analyzer-optimize -dce full`
